### PR TITLE
add `_to_eltype` supports

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,8 +6,22 @@ We note that this package has some overlap with [TypeUtils.jl](https://github.co
 
 ## Introduction
 
-### `elconvert`
+### `elconvert` and `_to_eltype`
 `elconvert(T, x)` works like `convert(T, x)`, except that `T` refers to the eltype of the result. This can be useful for generic codes.
+
+It should be always true that `elconvert(T, x) isa _to_eltype(T, typeof(x))`. However, since `elconvert` and `_to_eltype` use different routines, it's possible that the equality doesn't hold for some types. Please submit an issue or PR if that happens.
+
+If `typeof(x)` is not in Base or stdlib, the package who owns the type should implement corresponding `_to_eltype` or `elconvert`. `elconvert` has fallbacks, in which case it could be unnecessary:
+- For a subtype of `AbstractArray`, `elconvert` calls the constructor `AbstractArray{T}` and `_to_eltype` returns `Array`.
+- For a subtype of `AbstractUnitRange`, `elconvert` calls the constructor `AbstractUnitRange{T}`.
+- For a subtype of `AbstractRange`, `elconvert` uses broadcast through `map`.
+- For a `Tuple`, `elconvert` uses dot broadcast.
+- For other types, `elconvert` calls `convert` and `_to_eltype`.
+
+However, `_to_eltype` must be implemented for each type to support `baseconvert` and `precisionconvert`. The following types from Base and stdlib are explicitly supported by `_to_eltype`:
+```
+AbstractArray, AbstractDict, AbstractSet, Adjoint, Bidiagonal, CartesianIndices, Diagonal, Dict, Hermitian, Set, StepRangeLen, Symmetric, SymTridiagonal, Transpose, TwicePrecision, UnitRange
+```
 
 ### `basetype` and `precisiontype`
 The `basetype` is used for nested collections, where `eltype` is repeatedly applied until the bottom. `precisiontype` has a similar idea, but goes deeper when possible. `precisiontype` is used to manipulate the accuracy of (nested) collections.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,7 +20,7 @@ If `typeof(x)` is not in Base or stdlib, the package who owns the type should im
 
 However, `_to_eltype` must be implemented for each type to support `baseconvert` and `precisionconvert`. The following types from Base and stdlib are explicitly supported by `_to_eltype`:
 ```
-AbstractArray, AbstractDict, AbstractSet, Adjoint, Bidiagonal, CartesianIndices, Diagonal, Dict, Hermitian, Set, StepRangeLen, Symmetric, SymTridiagonal, Transpose, TwicePrecision, UnitRange
+AbstractArray, AbstractDict, AbstractSet, Adjoint, Bidiagonal, BitArray, CartesianIndices, Diagonal, Dict, Hermitian, Set, StepRangeLen, Symmetric, SymTridiagonal, Transpose, TwicePrecision, UnitRange
 ```
 
 ### `basetype` and `precisiontype`

--- a/src/EltypeExtensions.jl
+++ b/src/EltypeExtensions.jl
@@ -54,9 +54,10 @@ _to_eltype(::Type{T}, ::Type{Array{S,N}}) where {T,S,N} = Array{T,N}
 _to_eltype(::Type{T}, ::Type{<:Set}) where T = Set{T}
 _to_eltype(::Type{T}, ::Type{<:TwicePrecision}) where T = TwicePrecision{T}
 
-_to_eltype(::Type{T}, ::Type{BitArray}) = Array{T}
+_to_eltype(::Type{T}, ::Type{BitArray}) where T = Array{T}
 _to_eltype(::Type{T}, ::Type{BitArray{N}}) where {T,N} = Array{T,N}
-_to_eltype(::Type{Bool}, ::Type{S}) where S<:BitArray = S
+_to_eltype(::Type{Bool}, ::Type{BitArray}) = BitArray
+_to_eltype(::Type{Bool}, ::Type{BitArray{N}}) where N = BitArray{N}
 
 for TYP in (Adjoint, Bidiagonal, Diagonal, Hermitian, Symmetric, SymTridiagonal, Transpose)
     @eval _to_eltype(::Type{T}, ::Type{$TYP}) where T = $TYP{T}

--- a/src/EltypeExtensions.jl
+++ b/src/EltypeExtensions.jl
@@ -1,6 +1,6 @@
 module EltypeExtensions
 
-import Base: convert
+import Base: convert, TwicePrecision
 using LinearAlgebra # to support 1.0, not using package extensions
 import LinearAlgebra: AbstractQ
 
@@ -45,6 +45,8 @@ Convert type `S` to have the `eltype` of `T`. See also [`elconvert`](@ref).
 _to_eltype(::Type{T}, ::Type{S}) where {T,S} = eltype(S) == S ? T : eltype(S) == T ? S : MethodError(_to_eltype, T, S)
 _to_eltype(::Type{T}, ::Type{Array{S,N}}) where {T,S,N} = Array{T,N}
 _to_eltype(::Type{T}, ::Type{<:Set}) where T = Set{T}
+_to_eltype(::Type{T}, ::Type{<:TwicePrecision}) where T = TwicePrecision{T}
+
 for TYP in (Adjoint, Bidiagonal, Diagonal, Hermitian, Symmetric, SymTridiagonal, Transpose)
     @eval _to_eltype(::Type{T}, ::Type{$TYP}) where T = $TYP{T}
     @eval _to_eltype(::Type{T}, ::Type{$TYP{S}}) where {T,S} = $TYP{T}

--- a/src/EltypeExtensions.jl
+++ b/src/EltypeExtensions.jl
@@ -53,7 +53,6 @@ for TYP in (Adjoint, Bidiagonal, Diagonal, Hermitian, Symmetric, SymTridiagonal,
     @eval _to_eltype(::Type{T}, ::Type{$TYP{S,M}}) where {T,S,M} = $TYP{T,_to_eltype(T,M)}
     @eval elconvert(::Type{T}, A::S) where {T,S<:$TYP} = convert(_to_eltype(T, S), A)
 end
-_to_eltype(::Type{T}, ::Type{<:UnitRange}) where T<:Integer = UnitRange{T}
 
 @static if VERSION >= v"1.6"
     _to_eltype(::Type{CartesianIndex{N}}, ::Type{CartesianIndices{N,R}}) where {N, R<:Tuple{Vararg{OrdinalRange{Int64, Int64}, N}}} = CartesianIndices{N,R}
@@ -63,10 +62,13 @@ end
 _to_eltype(::Type{T}, ::Type{<:CartesianIndices}) where T = Array{T}
 
 @static if VERSION >= v"1.7"
-    _to_eltype(::Type{T}, ::Type{<:UnitRange}) where T<:Real = StepRangeLen{T,Base.TwicePrecision{T},Base.TwicePrecision{T},Int}
+    _to_eltype(::Type{T}, ::Type{<:StepRangeLen}) where T<:Real = StepRangeLen{T,_to_eltype(T,TwicePrecision),_to_eltype(T,TwicePrecision),Int}
+    
 else
-    _to_eltype(::Type{T}, ::Type{<:UnitRange}) where T<:Real = StepRangeLen{T,Base.TwicePrecision{T},Base.TwicePrecision{T}}
+    _to_eltype(::Type{T}, ::Type{<:StepRangeLen}) where T<:Real = StepRangeLen{T,_to_eltype(T,TwicePrecision),_to_eltype(T,TwicePrecision)}
 end
+_to_eltype(::Type{T}, ::Type{<:UnitRange}) where T<:Integer = UnitRange{T}
+_to_eltype(::Type{T}, ::Type{<:UnitRange}) where T<:Real = _to_eltype(T, StepRangeLen)
 
 nutype(x) = nutype(typeof(x))
 nutype(T::Type) = throw(MethodError(nutype, T))

--- a/src/EltypeExtensions.jl
+++ b/src/EltypeExtensions.jl
@@ -36,6 +36,8 @@ elconvert(::Type{T}, A::AbstractArray) where T = convert(AbstractArray{T}, A)
 elconvert(::Type{T}, A::AbstractRange) where T = map(T, A)
 elconvert(::Type{T}, A::AbstractUnitRange) where T<:Integer = convert(AbstractUnitRange{T}, A)
 elconvert(::Type{T}, A::Tuple) where T = convert.(T, A)
+elconvert(::Type{T}, A::Set{T}) where T = A
+elconvert(::Type{T}, A::Set) where T = Set(convert.(T, A))
 
 """
     _to_eltype(T, S)
@@ -51,6 +53,10 @@ _to_eltype(::Type{Pair{K,V}}, ::Type{<:Dict}) where {K,V} = Dict{K,V}
 _to_eltype(::Type{T}, ::Type{Array{S,N}}) where {T,S,N} = Array{T,N}
 _to_eltype(::Type{T}, ::Type{<:Set}) where T = Set{T}
 _to_eltype(::Type{T}, ::Type{<:TwicePrecision}) where T = TwicePrecision{T}
+
+_to_eltype(::Type{T}, ::Type{BitArray}) = Array{T}
+_to_eltype(::Type{T}, ::Type{BitArray{N}}) where {T,N} = Array{T,N}
+_to_eltype(::Type{Bool}, ::Type{S}) where S<:BitArray = S
 
 for TYP in (Adjoint, Bidiagonal, Diagonal, Hermitian, Symmetric, SymTridiagonal, Transpose)
     @eval _to_eltype(::Type{T}, ::Type{$TYP}) where T = $TYP{T}

--- a/src/EltypeExtensions.jl
+++ b/src/EltypeExtensions.jl
@@ -10,7 +10,7 @@ export elconvert, basetype, baseconvert, precisiontype, precisionconvert
     _to_eltype(::Type{T}, ::Type{UpperHessenberg{S,M}}) where {T,S,M} = UpperHessenberg{T,_to_eltype(T,M)}
     elconvert(::Type{T}, A::UpperHessenberg{S,M}) where {T,S,M} = UpperHessenberg{T,_to_eltype(T,M)}(A)
 end
-@static if VERSION >= v"1.9"
+@static if VERSION < v"1.9"
     elconvert(::Type{T}, A::Bidiagonal{S,V}) where {T,S,V} = Bidiagonal{T,_to_eltype(T,V)}(A.dv, A.ev, A.uplo)
 end
 @static if VERSION >= v"1.10" # see https://github.com/JuliaLang/julia/pull/46196

--- a/src/EltypeExtensions.jl
+++ b/src/EltypeExtensions.jl
@@ -68,7 +68,7 @@ _to_eltype(::Type{T}, ::Type{Bidiagonal}) where T = Bidiagonal{T}
 _to_eltype(::Type{T}, ::Type{Bidiagonal{S}}) where {T,S} = Bidiagonal{T}
 _to_eltype(::Type{T}, ::Type{Bidiagonal{S,M}}) where {T,S,M} = Bidiagonal{T,_to_eltype(T,M)}
 
-for TYP in (Adjoint, Bidiagonal, Diagonal, Hermitian, Symmetric, SymTridiagonal, Transpose)
+for TYP in (Adjoint, Diagonal, Hermitian, Symmetric, SymTridiagonal, Transpose)
     @eval _to_eltype(::Type{T}, ::Type{$TYP}) where T = $TYP{T}
     @eval _to_eltype(::Type{T}, ::Type{$TYP{S}}) where {T,S} = $TYP{T}
     @eval _to_eltype(::Type{T}, ::Type{$TYP{S,M}}) where {T,S,M} = $TYP{T,_to_eltype(T,M)}

--- a/src/EltypeExtensions.jl
+++ b/src/EltypeExtensions.jl
@@ -45,6 +45,9 @@ Convert type `S` to have the `eltype` of `T`. See also [`elconvert`](@ref).
 _to_eltype(::Type{T}, ::Type{S}) where {T,S} = eltype(S) == S ? T : eltype(S) == T ? S : MethodError(_to_eltype, T, S)
 _to_eltype(::Type{T}, ::Type{<:AbstractArray{S,N}}) where {T,S,N} = AbstractArray{T,N}
 _to_eltype(::Type{T}, ::Type{<:AbstractSet}) where T = AbstractSet{T}
+_to_eltype(::Type{Pair{K,V}}, ::Type{<:AbstractDict}) where {K,V} = AbstractDict{K,V}
+_to_eltype(::Type{Pair{K,V}}, ::Type{<:Dict}) where {K,V} = Dict{K,V}
+
 _to_eltype(::Type{T}, ::Type{Array{S,N}}) where {T,S,N} = Array{T,N}
 _to_eltype(::Type{T}, ::Type{<:Set}) where T = Set{T}
 _to_eltype(::Type{T}, ::Type{<:TwicePrecision}) where T = TwicePrecision{T}

--- a/src/EltypeExtensions.jl
+++ b/src/EltypeExtensions.jl
@@ -11,7 +11,7 @@ export elconvert, basetype, baseconvert, precisiontype, precisionconvert
     elconvert(::Type{T}, A::UpperHessenberg{S,M}) where {T,S,M} = UpperHessenberg{T,_to_eltype(T,M)}(A)
 end
 @static if VERSION >= v"1.9"
-    elconvert(::Type{T}, A::S) where {T,S<:$TYP} = convert(_to_eltype(T, S), A)
+    elconvert(::Type{T}, A::S) where {T,S<:Bidiagonal} = convert(_to_eltype(T, S), A)
 else
     elconvert(::Type{T}, A::Bidiagonal{S,V}) where {T,S,V} = Bidiagonal{T,_to_eltype(T,V)}(A.dv, A.ev, A.uplo)
 end

--- a/src/EltypeExtensions.jl
+++ b/src/EltypeExtensions.jl
@@ -10,6 +10,9 @@ export elconvert, basetype, baseconvert, precisiontype, precisionconvert
     _to_eltype(::Type{T}, ::Type{UpperHessenberg{S,M}}) where {T,S,M} = UpperHessenberg{T,_to_eltype(T,M)}
     elconvert(::Type{T}, A::UpperHessenberg{S,M}) where {T,S,M} = UpperHessenberg{T,_to_eltype(T,M)}(A)
 end
+@static if VERSION >= v"1.9"
+    elconvert(::Type{T}, A::Bidiagonal{S,V}) where {T,S,V} = Bidiagonal{T,_to_eltype(T,V)}(A.dv, A.ev, A.uplo)
+end
 @static if VERSION >= v"1.10" # see https://github.com/JuliaLang/julia/pull/46196
     elconvert(::Type{T}, A::AbstractQ) where T = convert(AbstractQ{T}, A)
     @inline bigfloatconvert(x, prec) = BigFloat(x, precision = prec)

--- a/src/EltypeExtensions.jl
+++ b/src/EltypeExtensions.jl
@@ -43,6 +43,8 @@ elconvert(::Type{T}, A::Tuple) where T = convert.(T, A)
 Convert type `S` to have the `eltype` of `T`. See also [`elconvert`](@ref).
 """
 _to_eltype(::Type{T}, ::Type{S}) where {T,S} = eltype(S) == S ? T : eltype(S) == T ? S : MethodError(_to_eltype, T, S)
+_to_eltype(::Type{T}, ::Type{<:AbstractArray{S,N}}) where {T,S,N} = AbstractArray{T,N}
+_to_eltype(::Type{T}, ::Type{<:AbstractSet}) where T = AbstractSet{T}
 _to_eltype(::Type{T}, ::Type{Array{S,N}}) where {T,S,N} = Array{T,N}
 _to_eltype(::Type{T}, ::Type{<:Set}) where T = Set{T}
 _to_eltype(::Type{T}, ::Type{<:TwicePrecision}) where T = TwicePrecision{T}

--- a/src/EltypeExtensions.jl
+++ b/src/EltypeExtensions.jl
@@ -45,7 +45,7 @@ Convert type `S` to have the `eltype` of `T`. See also [`elconvert`](@ref).
 _to_eltype(::Type{T}, ::Type{S}) where {T,S} = eltype(S) == S ? T : eltype(S) == T ? S : MethodError(_to_eltype, T, S)
 _to_eltype(::Type{T}, ::Type{Array{S,N}}) where {T,S,N} = Array{T,N}
 _to_eltype(::Type{T}, ::Type{<:Set}) where T = Set{T}
-for TYP in (Adjoint, Diagonal, Hermitian, Symmetric, SymTridiagonal, Transpose)
+for TYP in (Adjoint, Bidiagonal, Diagonal, Hermitian, Symmetric, SymTridiagonal, Transpose)
     @eval _to_eltype(::Type{T}, ::Type{$TYP}) where T = $TYP{T}
     @eval _to_eltype(::Type{T}, ::Type{$TYP{S}}) where {T,S} = $TYP{T}
     @eval _to_eltype(::Type{T}, ::Type{$TYP{S,M}}) where {T,S,M} = $TYP{T,_to_eltype(T,M)}

--- a/src/EltypeExtensions.jl
+++ b/src/EltypeExtensions.jl
@@ -10,7 +10,9 @@ export elconvert, basetype, baseconvert, precisiontype, precisionconvert
     _to_eltype(::Type{T}, ::Type{UpperHessenberg{S,M}}) where {T,S,M} = UpperHessenberg{T,_to_eltype(T,M)}
     elconvert(::Type{T}, A::UpperHessenberg{S,M}) where {T,S,M} = UpperHessenberg{T,_to_eltype(T,M)}(A)
 end
-@static if VERSION < v"1.9"
+@static if VERSION >= v"1.9"
+    elconvert(::Type{T}, A::S) where {T,S<:$TYP} = convert(_to_eltype(T, S), A)
+else
     elconvert(::Type{T}, A::Bidiagonal{S,V}) where {T,S,V} = Bidiagonal{T,_to_eltype(T,V)}(A.dv, A.ev, A.uplo)
 end
 @static if VERSION >= v"1.10" # see https://github.com/JuliaLang/julia/pull/46196
@@ -61,6 +63,10 @@ _to_eltype(::Type{T}, ::Type{BitArray}) where T = Array{T}
 _to_eltype(::Type{T}, ::Type{BitArray{N}}) where {T,N} = Array{T,N}
 _to_eltype(::Type{Bool}, ::Type{BitArray}) = BitArray
 _to_eltype(::Type{Bool}, ::Type{BitArray{N}}) where N = BitArray{N}
+
+_to_eltype(::Type{T}, ::Type{Bidiagonal}) where T = Bidiagonal{T}
+_to_eltype(::Type{T}, ::Type{Bidiagonal{S}}) where {T,S} = Bidiagonal{T}
+_to_eltype(::Type{T}, ::Type{Bidiagonal{S,M}}) where {T,S,M} = Bidiagonal{T,_to_eltype(T,M)}
 
 for TYP in (Adjoint, Bidiagonal, Diagonal, Hermitian, Symmetric, SymTridiagonal, Transpose)
     @eval _to_eltype(::Type{T}, ::Type{$TYP}) where T = $TYP{T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,8 @@ end
     testelconvert(Float16, Bidiagonal(A, :U))
     testelconvert(Float16, Bidiagonal(A, :L))
     testelconvert(Float16, Set(A))
+    testelconvert(Bool, A .> 0.5)
+    testelconvert(Float16, A .> 0.5)
     
     r = 1:5
     testelconvert(Int8, r)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ end
     testelconvert(Float16, Hermitian(A))
     testelconvert(Float16, Bidiagonal(A, :U))
     testelconvert(Float16, Bidiagonal(A, :L))
+    testelconvert(Float16, Set(A))
     
     r = 1:5
     testelconvert(Int8, r)
@@ -30,6 +31,9 @@ end
     inds = CartesianIndex(1,1):CartesianIndex(3,3)
     testelconvert(CartesianIndex{2}, inds)
     testelconvert(Tuple, inds)
+
+    dict = Dict(1=>2)
+    testelconvert(Pair{Float64,Float32}, dict)
 end
 
 @testset "bugs" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,8 @@ end
         testelconvert(Float16, UpperHessenberg(A))
     end
     testelconvert(Float16, Hermitian(A))
+    testelconvert(Float16, Bidiagonal(A, :U))
+    testelconvert(Float16, Bidiagonal(A, :L))
     
     r = 1:5
     testelconvert(Int8, r)


### PR DESCRIPTION
- Bidiagonal
- TwicePrecision
- StepRangeLen
- AbstractArray
- AbstractSet
- Dict
- AbstractDict
- BitArray